### PR TITLE
Added new test case for invalid delete; improved login_new_user and f…

### DIFF
--- a/tests/api/test_nanopub_crud.py
+++ b/tests/api/test_nanopub_crud.py
@@ -60,6 +60,21 @@ class TestNanopubCrud(ApiTestCase):
         response = self.client.delete("/pub/"+nanopub_id, follow_redirects=True)
         self.assertEquals(response.status, '204 NO CONTENT')
 
+    def test_delete_invalid(self):
+        self.login_new_user(email="user1@example.com", username="identifier1", role=None)
+
+        response = self.post_nanopub(data=self.turtle,
+                                        content_type="text/turtle",
+                                        expected_headers=["Location"])
+
+        nanopub_id = response.headers['Location'].split('/')[-1]
+
+        self.client.post("/logout", follow_redirects=True)
+        self.login_new_user(email="user2@example.com", username="identifier2", role=None)
+
+        response = self.client.delete("/pub/"+nanopub_id, follow_redirects=True)
+        self.assertEquals(response.status,'401 UNAUTHORIZED')
+
     def test_linked_data(self):
         self.login_new_user()
         self.post_nanopub(data=self.turtle,

--- a/tests/api/view/test_nanopublications_json_view.py
+++ b/tests/api/view/test_nanopublications_json_view.py
@@ -19,4 +19,4 @@ class TestNanopublicationsJsonView(ApiTestCase):
         self.assertEqual(1, len(json_content))
         nanopublication = json_content[0]
         self.assertIsInstance(nanopublication, dict)
-        self.assertEqual(nanopublication["contributor"], LOD_PREFIX + '/user/Admin')
+        self.assertEqual(nanopublication["contributor"], LOD_PREFIX + '/user/identifier')

--- a/whyis/test/api_test_case.py
+++ b/whyis/test/api_test_case.py
@@ -6,8 +6,8 @@ from flask import Response
 
 class ApiTestCase(TestCase):
 
-    def login_new_user(self, *, email: str = "user@example.com", password: str = "password", role: str = 'Admin') -> Response:
-        return self.login(*self.create_user(email, password, role))
+    def login_new_user(self, *, email: str = "user@example.com", password: str = "password", username: str = "identifier", role: str = 'Admin') -> Response:
+        return self.login(*self.create_user(email=email, password=password, username=username, roles=role))
 
     def get_view(self, *, uri: URIRef, mime_type: str, view: Optional[str] = None, headers = None, expected_template: Optional[str] = None, query_string: Optional[Dict[str, str]]=None) -> Response:
         query_string = query_string.copy() if query_string is not None else {}


### PR DESCRIPTION
Added a test that creates a nanopub with one user, then verifies that a different user cannot delete it. Doing this required changing `login_new_user` to take a username parameter, which in turn revealed the source of a test failure in test_nanopublication_json_view.