### PR TITLE
Fix blazegraph permission issues

### DIFF
--- a/docker/compose/split/db/docker-compose.yml
+++ b/docker/compose/split/db/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     ports:
       - "127.0.0.1:6379:6379"
     volumes:
-      - ./../../../../../../data:/data
+      - ./../../../../../../data/redis:/data
   blazegraph:
     build:
       args:

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -77,7 +77,7 @@ The monolithic image was split into images for the databases Whyis relies on (_r
 #### Prerequisites 
 * Docker
 * `docker-compose`
-* A data folder in the same directory as your app and Whyis with permissions 777
+* A data folder alongside your `/apps` folder is in with permissions 777
   * See other notes
 
 ### Use
@@ -106,9 +106,9 @@ Further, `docker/compose/split/app-dev` references a version of `whyis-server` t
 
 ### Data directory
 
-By default, the split `docker-compose.yml` will mount a directory named `data` in the same directory as your Whyis folder on the host machine. Due to how Docker allocates volumes, this folder will have the wrong permissions and cause Blazegraph to fail on the first setup. To avoid this, run the following instructions before running `docker-compose`:
+By default, the split `docker-compose.yml` will mount a directory named `data` in the same directory as your `/apps` folder on the host machine. Due to how Docker allocates volumes, this folder will have the wrong permissions and cause Blazegraph to fail on the first setup. To avoid this, run the following instructions before running `docker-compose`:
 
-	cd FOLDER_CONTAINING_WHYIS_FOLDER
+	cd /
 	mkdir data
 	chmod ugo+rwx data
 	

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -77,6 +77,8 @@ The monolithic image was split into images for the databases Whyis relies on (_r
 #### Prerequisites 
 * Docker
 * `docker-compose`
+* A data folder in the same directory as your app and Whyis with permissions 777
+  * See other notes
 
 ### Use
 
@@ -101,6 +103,16 @@ The `db/docker-compose.yml` can be used to start the databases without the serve
 Further, `docker/compose/split/app-dev` references a version of `whyis-server` that mounts `/apps` from the parent directory of the current whyis checkout, for local development.
 
 ## Other notes
+
+### Data directory
+
+By default, the split `docker-compose.yml` will mount a directory named `data` in the same directory as your Whyis folder on the host machine. Due to how Docker allocates volumes, this folder will have the wrong permissions and cause Blazegraph to fail on the first setup. To avoid this, run the following instructions before running `docker-compose`:
+
+	cd FOLDER_CONTAINING_WHYIS_FOLDER
+	mkdir data
+	chmod ugo+rwx data
+	
+You should then be able to start and stop the containers without further permission issues.
 
 ### Whyis image tags
 


### PR DESCRIPTION
Some work still needs to be done for the initial startup, but `redis` should no longer overwrite the permissions of the `data` folder.