### PR TITLE
File archive agents

### DIFF
--- a/main.py
+++ b/main.py
@@ -247,8 +247,10 @@ class App(Empty):
         if self.file_depot is None:
             DepotManager.configure('files', self.config['file_archive'])
             self.file_depot = DepotManager.get('files')
-        if DepotManager.get('nanopublications') is None:
+        self.nanopub_depot = DepotManager.get('nanopublications')
+        if self.nanopub_depot is None:
             DepotManager.configure('nanopublications', self.config['nanopub_archive'])
+            self.nanopub_depot = DepotManager.get('nanopublications')
 
     def __weighted_route(self, *args, **kwargs):
         """

--- a/tests/unit/whyis_test/autonomic/test_frir_agent.py
+++ b/tests/unit/whyis_test/autonomic/test_frir_agent.py
@@ -27,7 +27,6 @@ class SETLRAgentTestCase(AgentUnitTestCase):
         np = list(self.app.nanopub_manager.prepare(g))[0]
         self.app.nanopub_manager.publish(np)
 
-        print(np.serialize(format='trig').decode('utf8'))
         agent = autonomic.FRIRArchiver()
         results = self.run_agent(agent, nanopublication=np)
 
@@ -38,13 +37,9 @@ class SETLRAgentTestCase(AgentUnitTestCase):
         #data = file_handle.read()
         #digest = hashlib.sha256(data).hexdigest()
         #self.assertEquals(pmanif[digest], manifestation)
-        print(np.identifier, len(np), expression, manifestation)
         
         content = self.client.get("/about",query_string={"uri":manifestation},
                                   follow_redirects=True)
-        print(content.data.decode('utf8'))
         self.assertEquals(content.mimetype, "application/n-quads")
-        digest = hashlib.sha256(content.data).hexdigest()
-        print (pmanif[digest])
-        print(manifestation)
+        digest = hashlib.sha256(content.data).hexdigest().lstrip('0')
         self.assertEquals(pmanif[digest], manifestation)

--- a/tests/unit/whyis_test/autonomic/test_frir_agent.py
+++ b/tests/unit/whyis_test/autonomic/test_frir_agent.py
@@ -1,0 +1,50 @@
+import os
+from base64 import b64encode
+
+from rdflib import *
+
+import json
+from io import StringIO
+
+from whyis import nanopub
+from whyis.namespace import *
+
+from whyis import autonomic
+from whyis.test.agent_unit_test_case import AgentUnitTestCase
+from tests.api.api_test_data import PERSON_INSTANCE_TRIG
+import hashlib
+
+pmanif = Namespace('tag:tw.rpi.edu,2011:manifestation_sha256-')
+
+class SETLRAgentTestCase(AgentUnitTestCase):
+
+    def test_basic_file_storage(self):
+        self.login_new_user()
+        self.dry_run = False
+        
+        g = ConjunctiveGraph()
+        g.parse(data=PERSON_INSTANCE_TRIG, format="trig")
+        np = list(self.app.nanopub_manager.prepare(g))[0]
+        self.app.nanopub_manager.publish(np)
+
+        print(np.serialize(format='trig').decode('utf8'))
+        agent = autonomic.FRIRArchiver()
+        results = self.run_agent(agent, nanopublication=np)
+
+        expression = results[0].value(np.identifier, frbr.realization)
+        manifestation = results[0].value(expression, frbr.embodiment)
+        #fileid = results[0].value(manifestation, whyis.hasFileID)
+        #file_handle = self.app.nanopub_depot.get(fileid)
+        #data = file_handle.read()
+        #digest = hashlib.sha256(data).hexdigest()
+        #self.assertEquals(pmanif[digest], manifestation)
+        print(np.identifier, len(np), expression, manifestation)
+        
+        content = self.client.get("/about",query_string={"uri":manifestation},
+                                  follow_redirects=True)
+        print(content.data.decode('utf8'))
+        self.assertEquals(content.mimetype, "application/n-quads")
+        digest = hashlib.sha256(content.data).hexdigest()
+        print (pmanif[digest])
+        print(manifestation)
+        self.assertEquals(pmanif[digest], manifestation)

--- a/tests/unit/whyis_test/autonomic/test_frir_agent.py
+++ b/tests/unit/whyis_test/autonomic/test_frir_agent.py
@@ -58,3 +58,18 @@ class FRIRAgentTestCase(AgentUnitTestCase):
         self.app.nanopub_manager.retire(np.identifier)
         self.assertFalse(self.app.nanopub_depot.exists(fileid))
         
+    def test_no_self_archive(self):
+        self.login_new_user()
+        self.dry_run = False
+        
+        g = ConjunctiveGraph()
+        g.parse(data=PERSON_INSTANCE_TRIG, format="trig")
+        np = list(self.app.nanopub_manager.prepare(g))[0]
+        self.app.nanopub_manager.publish(np)
+
+        agent = autonomic.FRIRArchiver()
+        results = self.run_agent(agent, nanopublication=np)
+
+        second_results = self.run_agent(agent,nanopublication=results[0])
+        self.assertEquals(len(second_results),0)
+        

--- a/tests/unit/whyis_test/autonomic/test_ontology_importer.py
+++ b/tests/unit/whyis_test/autonomic/test_ontology_importer.py
@@ -25,10 +25,6 @@ class OntologyImportAgentTestCase(AgentUnitTestCase):
         agent = autonomic.OntologyImporter()
 
         results = self.run_agent(agent, nanopublication=np)
-        for r in results[0].contexts():
-            print(r.identifier, len(r))
-            if len(r) < 10:
-                print(r.serialize(format="turtle").decode('utf8'))
         self.assertEquals(len(results), 1)
         self.assertTrue(results[0].resource(URIRef('http://xmlns.com/foaf/0.1/'))[RDF.type:OWL.Ontology])
 

--- a/tests/unit/whyis_test/autonomic/test_setlr_agents.py
+++ b/tests/unit/whyis_test/autonomic/test_setlr_agents.py
@@ -1,0 +1,169 @@
+import os
+from base64 import b64encode
+
+from rdflib import *
+
+import json
+from io import StringIO
+
+from whyis import nanopub
+
+from whyis import autonomic
+from whyis.test.agent_unit_test_case import AgentUnitTestCase
+
+test_setl_script = """
+@prefix rdf:           <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:          <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:           <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl:           <http://www.w3.org/2002/07/owl#> .
+@prefix prov:          <http://www.w3.org/ns/prov#> .
+@prefix dcat:          <http://www.w3.org/ns/dcat#> .
+@prefix dcterms:       <http://purl.org/dc/terms/> .
+@prefix void:          <http://rdfs.org/ns/void#> .
+@prefix setl:          <http://purl.org/twc/vocab/setl/> .
+@prefix csvw:          <http://www.w3.org/ns/csvw#> .
+@prefix pv:            <http://purl.org/net/provenance/ns#> .
+@prefix :              <http://example.com/setl/> .
+
+:table a owl:Class, prov:SoftwareAgent, setl:PythonScript;
+  rdfs:subClassOf prov:Activity;
+  prov:value '''
+import pandas as pd
+table = pd.DataFrame({
+  "ID":['Alice', 'Bob', 'Charles', 'Dave'],
+  "Name" : ['Alice Smith', 'Bob Smith', 'Charles Brown', 'Dave Jones'],
+  'MarriedTo' : ['Bob','Alice',None,None],
+  'Knows' : ['Bob; Charles', 'Alice; Charles', 'Alice; Bob', None],
+  'DOB' : ['1/12/1983', '3/23/1985', '12/15/1955', '4/25/1967']
+})
+result = table.iterrows()
+'''.
+
+:social_setl a setl:SemanticETLScript.
+
+<http://example.com/social> a void:Dataset;
+  prov:wasGeneratedBy :social_setl, [
+    a setl:Transform, setl:JSLDT;
+    prov:used :table;
+    setl:hasContext '''{
+  "foaf" : "http://xmlns.com/foaf/0.1/"
+}''';
+    prov:value '''[{
+  "@id": "https://example.com/social/{{row.ID}}",
+  "@type": "foaf:Person",
+  "foaf:name": "{{row.Name}}",
+  "http://schema.org/spouse": [{
+    "@if" : "not isempty(row.MarriedTo)",
+    "@id" : "https://example.com/social/{{row.ID}}"
+  }],
+  "foaf:knows": [{
+    "@if" : "not isempty(row.Knows)",
+    "@for" : "friend in row.Knows.split('; ')",
+    "@do" : { "@id" : "https://example.com/social/{{friend}}" }
+  }]
+}]'''].
+"""
+
+test_setl_nanopub_collection_script = """
+@prefix rdf:           <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs:          <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd:           <http://www.w3.org/2001/XMLSchema#> .
+@prefix owl:           <http://www.w3.org/2002/07/owl#> .
+@prefix prov:          <http://www.w3.org/ns/prov#> .
+@prefix dcat:          <http://www.w3.org/ns/dcat#> .
+@prefix dcterms:       <http://purl.org/dc/terms/> .
+@prefix void:          <http://rdfs.org/ns/void#> .
+@prefix setl:          <http://purl.org/twc/vocab/setl/> .
+@prefix csvw:          <http://www.w3.org/ns/csvw#> .
+@prefix pv:            <http://purl.org/net/provenance/ns#> .
+@prefix :              <http://example.com/setl/> .
+@prefix nanopub: <http://www.nanopub.org/nschema#> .
+@prefix whyis:         <http://vocab.rpi.edu/whyis/>.
+
+
+:table a owl:Class, prov:SoftwareAgent, setl:PythonScript;
+  rdfs:subClassOf prov:Activity;
+  prov:value '''
+import pandas as pd
+table = pd.DataFrame({
+  "ID":['Alice', 'Bob', 'Charles', 'Dave'],
+  "Name" : ['Alice Smith', 'Bob Smith', 'Charles Brown', 'Dave Jones'],
+  'MarriedTo' : ['Bob','Alice',None,None],
+  'Knows' : ['Bob; Charles', 'Alice; Charles', 'Alice; Bob', None],
+  'DOB' : ['1/12/1983', '3/23/1985', '12/15/1955', '4/25/1967']
+})
+result = table.iterrows()
+'''.
+
+:social_setl a setl:SemanticETLScript.
+
+<http://example.com/social> a void:Dataset, whyis:NanopublicationCollection;
+  prov:wasGeneratedBy :social_setl, [
+    a setl:Transform, setl:JSLDT;
+    prov:used :table;
+    prov:qualifiedUsage [ a prov:Usage; prov:entity whyis:Nanopublication; prov:hadRole [ dcterms:identifier "Nanopublication"]];
+    setl:hasContext '''{
+  "foaf" : "http://xmlns.com/foaf/0.1/"
+}''';
+    prov:value '''[
+{
+  "@with": "Nanopublication() as np",
+  "@do": 
+    {
+      "@id": "{{np.identifier}}",
+      "@graph": [
+        {
+          "@id": "{{np.identifier}}",
+          "@type" : "nanopub:Nanopublication",
+          "sio:isAbout" : { "@id" : "https://example.com/social/{{row.ID}}" },
+          "nanopub:hasAssertion" : {
+            "@id": "https://example.com/social/{{row.ID}}",
+            "@type": "foaf:Person",
+            "foaf:name": "{{row.Name}}",
+            "http://schema.org/spouse": [{
+              "@if" : "not isempty(row.MarriedTo)",
+              "@id" : "https://example.com/social/{{row.ID}}"
+            }],
+            "foaf:knows": [{
+              "@if" : "not isempty(row.Knows)",
+              "@for" : "friend in row.Knows.split('; ')",
+              "@do" : { "@id" : "https://example.com/social/{{friend}}" }
+            }]
+          }
+        }
+      ]
+    }
+}]'''].
+"""
+
+class SETLRAgentTestCase(AgentUnitTestCase):
+
+    def test_basic_setl(self):
+        self.dry_run = False
+        
+        np = nanopub.Nanopublication()
+        np.assertion.parse(data=test_setl_script, format="turtle")
+        #print(np.serialize(format="trig"))
+        agent = autonomic.SETLr()
+
+        results = self.run_agent(agent, nanopublication=np)
+
+        persons = list(self.app.db.subjects(RDF.type, URIRef('http://xmlns.com/foaf/0.1/Person')))
+        self.assertEquals(len(persons), 4)
+
+    def test_nanopub_collection_setl(self):
+        self.dry_run = False
+        
+        np = nanopub.Nanopublication()
+        np.assertion.parse(data=test_setl_nanopub_collection_script, format="turtle")
+        #print(np.serialize(format="trig"))
+        agent = autonomic.SETLr()
+
+        results = self.run_agent(agent, nanopublication=np)
+
+        persons = list(self.app.db.subjects(RDF.type, URIRef('http://xmlns.com/foaf/0.1/Person')))
+        self.assertEquals(len(persons), 4)
+
+        persons = list(self.app.db.subjects(RDF.type, self.app.NS.np.Nanopublication))
+        self.assertEquals(len(persons), 6)
+

--- a/tests/unit/whyis_test/autonomic/test_setlr_agents.py
+++ b/tests/unit/whyis_test/autonomic/test_setlr_agents.py
@@ -64,7 +64,6 @@ result = table.iterrows()
 }]'''].
 """
 
-<<<<<<< HEAD
 test_setl_nanopub_collection_script = """
 @prefix rdf:           <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs:          <http://www.w3.org/2000/01/rdf-schema#> .
@@ -104,7 +103,8 @@ result = table.iterrows()
     prov:used :table;
     prov:qualifiedUsage [ a prov:Usage; prov:entity whyis:Nanopublication; prov:hadRole [ dcterms:identifier "Nanopublication"]];
     setl:hasContext '''{
-  "foaf" : "http://xmlns.com/foaf/0.1/"
+  "foaf" : "http://xmlns.com/foaf/0.1/",
+  "nanopub" : "http://www.nanopub.org/nschema#"
 }''';
     prov:value '''[
 {
@@ -118,18 +118,21 @@ result = table.iterrows()
           "@type" : "nanopub:Nanopublication",
           "sio:isAbout" : { "@id" : "https://example.com/social/{{row.ID}}" },
           "nanopub:hasAssertion" : {
-            "@id": "https://example.com/social/{{row.ID}}",
-            "@type": "foaf:Person",
-            "foaf:name": "{{row.Name}}",
-            "http://schema.org/spouse": [{
-              "@if" : "not isempty(row.MarriedTo)",
-              "@id" : "https://example.com/social/{{row.ID}}"
-            }],
-            "foaf:knows": [{
-              "@if" : "not isempty(row.Knows)",
-              "@for" : "friend in row.Knows.split('; ')",
-              "@do" : { "@id" : "https://example.com/social/{{friend}}" }
-            }]
+            "@id" : "{{np.assertion.identifier}}",
+            "@graph" : {
+              "@id": "https://example.com/social/{{row.ID}}",
+              "@type": "foaf:Person",
+              "foaf:name": "{{row.Name}}",
+              "http://schema.org/spouse": [{
+                "@if" : "not isempty(row.MarriedTo)",
+                "@id" : "https://example.com/social/{{row.ID}}"
+              }],
+              "foaf:knows": [{
+                "@if" : "not isempty(row.Knows)",
+                "@for" : "friend in row.Knows.split('; ')",
+                "@do" : { "@id" : "https://example.com/social/{{friend}}" }
+              }]
+            }
           }
         }
       ]
@@ -165,6 +168,6 @@ class SETLRAgentTestCase(AgentUnitTestCase):
         persons = list(self.app.db.subjects(RDF.type, URIRef('http://xmlns.com/foaf/0.1/Person')))
         self.assertEquals(len(persons), 4)
 
-        persons = list(self.app.db.subjects(RDF.type, self.app.NS.np.Nanopublication))
-        self.assertEquals(len(persons), 6)
+        nps = list(self.app.db.subjects(RDF.type, self.app.NS.np.Nanopublication))
+        self.assertEquals(len(nps), 4)
 

--- a/whyis/autonomic/__init__.py
+++ b/whyis/autonomic/__init__.py
@@ -1,5 +1,6 @@
 from .autonomic_setlr import SETLr
 from .crawler import Crawler
+from .frir import FRIRArchiver
 from .dataset_importer import DatasetImporter
 from .deductor import Deductor
 from .email_notifier import EmailNotifier
@@ -10,3 +11,4 @@ from .ontology_importer import OntologyImporter
 from .service import Service
 from .setl_maker import SETLMaker
 from .update_change_service import UpdateChangeService
+

--- a/whyis/autonomic/autonomic_setlr.py
+++ b/whyis/autonomic/autonomic_setlr.py
@@ -97,34 +97,16 @@ class SETLr(UpdateChangeService):
             else:
                 out = resources[output_graph]
                 out_conjunctive = rdflib.ConjunctiveGraph(store=out.store, identifier=output_graph)
-                # print "Generated graph", out.identifier, len(out), len(out_conjunctive)
-                nanopub_prepare_graph = rdflib.ConjunctiveGraph(store="Sleepycat")
-                nanopub_prepare_graph_tempdir = tempfile.mkdtemp()
-                nanopub_prepare_graph.store.open(nanopub_prepare_graph_tempdir, True)
-
-                mappings = {}
-
                 to_publish = []
                 triples = 0
-                for new_np in self.app.nanopub_manager.prepare(out_conjunctive, mappings=mappings,
-                                                               store=nanopub_prepare_graph.store):
+                for new_np in self.app.nanopub_manager.prepare(out_conjunctive):
                     self.explain(new_np, i, o)
-                    orig = [orig for orig, new in list(mappings.items()) if new == new_np.assertion.identifier]
-                    if len(orig) == 0:
-                        continue
-                    orig = orig[0]
-                    print(orig)
-                    if isinstance(orig, rdflib.URIRef):
-                        new_np.pubinfo.add((new_np.assertion.identifier, prov.wasQuotedFrom, orig))
-                        if orig in old_np_map:
-                            new_np.pubinfo.add((new_np.assertion.identifier, prov.wasRevisionOf, old_np_map[orig]))
                     print("Publishing %s with %s assertions." % (new_np.identifier, len(new_np.assertion)))
                     to_publish.append(new_np)
 
                 # triples += len(new_np)
                 # if triples > 10000:
                 self.app.nanopub_manager.publish(*to_publish)
-                nanopub_prepare_graph.store.close()
             print("Published")
         for resource, obj in list(resources.items()):
             if hasattr(i, 'close'):

--- a/whyis/autonomic/autonomic_setlr.py
+++ b/whyis/autonomic/autonomic_setlr.py
@@ -98,18 +98,15 @@ class SETLr(UpdateChangeService):
             else:
                 out = resources[output_graph]
                 out_conjunctive = rdflib.ConjunctiveGraph(store=out.store, identifier=output_graph)
-                print ("Generated graph", out.identifier, len(out), len(out_conjunctive))
                 to_publish = []
                 triples = 0
                 for new_np in self.app.nanopub_manager.prepare(out_conjunctive):
                     self.explain(new_np, i, o)
-                    print("Publishing %s with %s assertions." % (new_np.identifier, len(new_np.assertion)))
                     to_publish.append(new_np)
 
                 # triples += len(new_np)
                 # if triples > 10000:
                 self.app.nanopub_manager.publish(*to_publish)
-            print("Published")
         for resource, obj in list(resources.items()):
             if hasattr(i, 'close'):
                 print("Closing", resource)

--- a/whyis/autonomic/frir.py
+++ b/whyis/autonomic/frir.py
@@ -83,6 +83,7 @@ select distinct ?resource where {
         i.identifier.split('/')[-1]
         fileid = self.app.nanopub_depot.create(quads, i.identifier.split('/')[-1]+'.nq', "application/n-quads")
         o.add(rdflib.RDF.type, whyis.ArchivedNanopublication)
+        new_np.pubinfo.add((new_np.identifier, rdflib.RDF.type, whyis.FRIRNanopublication))
         expressions = dict([(part.identifier, self.expression_digest(part))
                             for part in [nanopub.assertion, nanopub.provenance, nanopub.pubinfo]])
         expressions[nanopub.identifier] = sum(expressions.values())

--- a/whyis/autonomic/frir.py
+++ b/whyis/autonomic/frir.py
@@ -56,8 +56,7 @@ class FRIRArchiver(UpdateChangeService):
     def __init__(self, expression_digest=rgda1_digest, manifestation_digest=sha256):
         self.expression_digest = expression_digest
         self.manifestation_digest = manifestation_digest
-        self.nanopub_depot = DepotManager.get('nanopublications')
-    
+        
     def getInputClass(self):
         return np.Nanopublication
 
@@ -82,7 +81,7 @@ select distinct ?resource where {
         nanopub = Nanopublication(i.graph.store, i.identifier)
         quads = nanopub.serialize(format="nquads")
         i.identifier.split('/')[-1]
-        fileid = self.nanopub_depot.create(quads, i.identifier.split('/')[-1]+'.nq', "application/n-quads")
+        fileid = self.app.nanopub_depot.create(quads, i.identifier.split('/')[-1]+'.nq', "application/n-quads")
         o.add(rdflib.RDF.type, whyis.ArchivedNanopublication)
         expressions = dict([(part.identifier, self.expression_digest(part))
                             for part in [nanopub.assertion, nanopub.provenance, nanopub.pubinfo]])
@@ -94,7 +93,7 @@ select distinct ?resource where {
             o.graph.add((work, rdflib.RDF.type, frbr.Work))
             o.graph.add((exp, rdflib.RDF.type, frbr.Expression))
         
-        with self.nanopub_depot.get(fileid) as stored_file:
+        with self.app.nanopub_depot.get(fileid) as stored_file:
             manifestation_id = self.manifestation_digest(stored_file)
         manifestation = pmanif[hex(manifestation_id)[2:]]
         o.graph.add((nanopub_expression_uri, frbr.embodiment, manifestation))

--- a/whyis/autonomic/frir.py
+++ b/whyis/autonomic/frir.py
@@ -1,0 +1,107 @@
+from builtins import str
+import sadi
+import rdflib
+import setlr
+from datetime import datetime
+from depot.manager import DepotManager
+
+from .update_change_service import UpdateChangeService
+from nanopub import Nanopublication
+from datastore import create_id
+import flask
+from flask import render_template
+from flask import render_template_string
+import logging
+
+import sys, traceback
+
+import database
+
+import tempfile
+
+from depot.io.interfaces import StoredFile
+
+from whyis.namespace import *
+
+import hashlib
+from uuid import uuid4
+
+from rdflib import compare
+
+pexp = rdflib.Namespace('tag:tw.rpi.edu,2011:expression_rgda1-sha256-')
+pmanif = rdflib.Namespace('tag:tw.rpi.edu,2011:manifestation_sha256-')
+nfo = rdflib.Namespace('http://www.semanticdesktop.org/ontologies/2007/03/22/nfo#')
+
+
+def rgda1_digest(graph):
+    g = rdflib.Graph()
+    g += graph
+    ig = compare.to_isomorphic(g)
+    return ig.graph_digest()
+
+def uuid(graph):
+    return int(uuid4())
+
+def sha256(f):
+    h = hashlib.sha256()
+    for chunk in iter(lambda: f.read(4096), b""):
+        h.update(chunk)
+    hd = h.hexdigest()
+    result = int(hd, 16)
+    return result
+
+class FRIRArchiver(UpdateChangeService):
+    activity_class = whyis.Archive
+
+    def __init__(self, expression_digest=rgda1_digest, manifestation_digest=sha256):
+        self.expression_digest = expression_digest
+        self.manifestation_digest = manifestation_digest
+        self.nanopub_depot = DepotManager.get('nanopublications')
+    
+    def getInputClass(self):
+        return np.Nanopublication
+
+    def getOutputClass(self):
+        return whyis.ArchivedNanopublication
+
+    def get_query(self):
+        return '''
+prefix setl: <http://purl.org/twc/vocab/setl/>
+select distinct ?resource where {
+  ?resource a np:Nanopublication.
+  filter not exists {
+    ?resource a whyis:FRIRNanopublication.
+  }
+  filter not exists {
+    ?resource a whyis:ArchivedNanopublication.
+  }
+}'''
+
+    def process_nanopub(self, i, o, new_np):
+        assertion = i.graph
+        nanopub = Nanopublication(i.graph.store, i.identifier)
+        quads = nanopub.serialize(format="nquads")
+        i.identifier.split('/')[-1]
+        fileid = self.nanopub_depot.create(quads, i.identifier.split('/')[-1]+'.nq', "application/n-quads")
+        o.add(rdflib.RDF.type, whyis.ArchivedNanopublication)
+        expressions = dict([(part.identifier, self.expression_digest(part))
+                            for part in [nanopub.assertion, nanopub.provenance, nanopub.pubinfo]])
+        expressions[nanopub.identifier] = sum(expressions.values())
+        nanopub_expression_uri = pexp[hex(expressions[nanopub.identifier])[2:]]
+        for work, expression in expressions.items():
+            exp = pexp[hex(expression)[2:]]
+            o.graph.add((work, frbr.realization, exp))
+            o.graph.add((work, rdflib.RDF.type, frbr.Work))
+            o.graph.add((exp, rdflib.RDF.type, frbr.Expression))
+        
+        with self.nanopub_depot.get(fileid) as stored_file:
+            manifestation_id = self.manifestation_digest(stored_file)
+        manifestation = pmanif[hex(manifestation_id)[2:]]
+        o.graph.add((nanopub_expression_uri, frbr.embodiment, manifestation))
+            
+        o.graph.add((manifestation, rdflib.RDF.type, pv.File))
+        o.graph.add((manifestation, whyis.hasFileID, rdflib.Literal(fileid)))
+        o.graph.add((manifestation, dc.created, rdflib.Literal(datetime.utcnow())))
+        o.graph.add((manifestation, NS.ov.hasContentType, rdflib.Literal("application/n-quads")))
+        o.graph.add((manifestation, rdflib.RDF.type, NS.mediaTypes["application/n-quads"]))
+        o.graph.add((NS.mediaTypes["application/n-quads"], rdflib.RDF.type, dc.FileFormat))

--- a/whyis/autonomic/service.py
+++ b/whyis/autonomic/service.py
@@ -77,6 +77,8 @@ class Service(sadi.Service):
                 # print new_np.serialize(format="trig")
                 if not self.dry_run:
                     self.app.nanopub_manager.publish(new_np)
+                else:
+                    print("Not publishing",new_np.identifier,", dry run.")
                 results.append(new_np)
         return results
 

--- a/whyis/blueprint/entity/get_entity.py
+++ b/whyis/blueprint/entity/get_entity.py
@@ -29,9 +29,14 @@ def view(name=None, format=None, view=None):
     fileid = resource.value(current_app.NS.whyis.hasFileID)
     if fileid is not None and 'view' not in request.args:
         print (resource.identifier, fileid)
-        f = current_app.file_depot.get(fileid)
-        fsa = FileServeApp(f, current_app.config["file_archive"].get("cache_max_age",3600*24*7))
-        return fsa
+        f = None
+        if current_app.file_depot.exists(fileid):
+            f = current_app.file_depot.get(fileid)
+        elif current_app.nanopub_depot.exists(fileid):
+            f = current_app.nanopub_depot.get(fileid)
+        if f is not None:
+            fsa = FileServeApp(f, current_app.config["file_archive"].get("cache_max_age",3600*24*7))
+            return fsa
             
     if content_type is None:
         content_type = request.headers['Accept'] if 'Accept' in request.headers else 'text/turtle'

--- a/whyis/config_defaults.py
+++ b/whyis/config_defaults.py
@@ -35,6 +35,7 @@ Config = dict(
     nanopub_archive = {
         'depot.storage_path' : "/data/nanopublications",
     },
+    delete_archive_nanopubs = False,
 
     file_archive = {
         'cache_max_age' : 3600*24*7,

--- a/whyis/nanopub/nanopublication_manager.py
+++ b/whyis/nanopub/nanopublication_manager.py
@@ -149,8 +149,7 @@ class NanopublicationManager(object):
         # session.delete(self.db.store.endpoint, data=[('c', c.n3()) for c in graphs])
 
     def is_current(self, nanopub_uri):
-        work = self.db.value(rdflib.URIRef(nanopub_uri), frbr.realizationOf)
-        return work is not None
+        return (rdflib.URIRef(nanopub_uri), rdflib.RDF.type, np.Nanopublication) in self.db
 
     def get_path(self, nanopub_uri):
         # print self.prefix, nanopub_uri

--- a/whyis/nanopub/nanopublication_manager.py
+++ b/whyis/nanopub/nanopublication_manager.py
@@ -15,7 +15,7 @@ from depot.manager import DepotManager
 from datetime import datetime
 import pytz
 
-from whyis.namespace import np, prov, dc, frbr
+from whyis.namespace import np, prov, dc, frbr, whyis
 from uuid import uuid4
 
 from datastore import create_id
@@ -120,17 +120,24 @@ class NanopublicationManager(object):
 
     def retire(self, *nanopub_uris):
         self.db.store.nsBindings = {}
-        graphs = []
+        #graphs = []
+        derived_query = '''select ?np where {
+  ?np (np:hasAssertion/prov:wasDerivedFrom+/^np:hasAssertion)? ?r.
+  ?np a np:Nanopublication.
+''' + ('' if self.app.config.get('delete_archive_nanopubs',True) else 'minus { ?np a whyis:FRIRNanopublication }') + '''
+}'''
         for nanopub_uri in nanopub_uris:
-            for np_uri, assertion, provenance, pubinfo in self.db.query('''select ?np ?assertion ?provenance ?pubinfo where {
-#    hint:Query hint:optimizer "Runtime" .
-    ?np (np:hasAssertion/prov:wasDerivedFrom+/^np:hasAssertion)? ?retiree.
-    ?np np:hasAssertion ?assertion;
-        np:hasPublicationInfo ?pubinfo;
-        np:hasProvenance ?provenance.
-}''', initNs={"prov": prov, "np": np}, initBindings={"retiree": nanopub_uri}):
-                graphs.extend([np_uri, assertion, provenance, pubinfo])
+            for np_uri, in self.db.query(derived_query,
+                                         initNs={"prov": prov, "np": np, "whyis" : whyis},
+                                         initBindings={"r": nanopub_uri}):
+                #graphs.extend([np_uri, assertion, provenance, pubinfo])
                 nanopub = Nanopublication(store=self.db.store, identifier=np_uri)
+                
+                for fileid in nanopub.objects(predicate=whyis.hasFileID):
+                    if self.app.file_depot.exists(fileid):
+                        self.app.file_depot.delete(fileid)
+                    elif self.app.nanopub_depot.exists(fileid):
+                        f = self.app.nanopub_depot.delete(fileid)                    
                 self.db.remove((None, None, None, nanopub.assertion.identifier))
                 self.db.remove((None, None, None, nanopub.provenance.identifier))
                 self.db.remove((None, None, None, nanopub.pubinfo.identifier))

--- a/whyis/test/agent_unit_test_case.py
+++ b/whyis/test/agent_unit_test_case.py
@@ -2,9 +2,12 @@ from .unit_test_case import UnitTestCase
 
 
 class AgentUnitTestCase(UnitTestCase):
+
+    dry_run = True
+    
     def run_agent(self, agent, nanopublication=None):
         app = self.app
-        agent.dry_run = True
+        agent.dry_run = self.dry_run
         agent.app = app
         results = []
         if nanopublication is not None:

--- a/whyis/test/agent_unit_test_case.py
+++ b/whyis/test/agent_unit_test_case.py
@@ -12,19 +12,15 @@ class AgentUnitTestCase(UnitTestCase):
         results = []
         if nanopublication is not None:
             results.extend(agent.process_graph(nanopublication))
-            print("Created",len(results),"nanopublications.")
         elif agent.query_predicate == app.NS.whyis.globalChangeQuery:
             results.extend(agent.process_graph(app.db))
         else:
-            print("Running as update agent")
             for resource in agent.getInstances(app.db):
-                print(resource.identifier)
                 for np_uri, in app.db.query('''select ?np where {
         graph ?assertion { ?e ?p ?o.}
         ?np a np:Nanopublication;
             np:hasAssertion ?assertion.
     }''', initBindings={'e': resource.identifier}, initNs=app.NS.prefixes):
-                    print(np_uri)
                     np = app.nanopub_manager.get(np_uri)
                     results.extend(agent.process_graph(np))
         return results

--- a/whyis/test/api_test_case.py
+++ b/whyis/test/api_test_case.py
@@ -6,29 +6,6 @@ from flask import Response
 
 class ApiTestCase(TestCase):
 
-    def login_new_user(self, *, email: str = "user@example.com", password: str = "password", username: str = "identifier", role: str = 'Admin') -> Response:
-        return self.login(*self.create_user(email=email, password=password, username=username, roles=role))
-
-    def get_view(self, *, uri: URIRef, mime_type: str, view: Optional[str] = None, headers = None, expected_template: Optional[str] = None, query_string: Optional[Dict[str, str]]=None) -> Response:
-        query_string = query_string.copy() if query_string is not None else {}
-        query_string["uri"] = uri
-        if view is not None:
-            query_string["view"] = view
-
-        content = self.client.get("/about",
-                                  query_string=query_string,
-                                  headers=headers or {},
-                                  follow_redirects=True)
-        
-        if expected_template is not None:
-            self.assertTemplateUsed(expected_template)
-
-        if mime_type is not None:
-            self.assertEqual(content.mimetype, mime_type,
-                              "Expected {}, got {} as response MIME type".format(mime_type, content.mimetype))
-
-        return content
-
     def post_nanopub(self, *, data: str, content_type: str, expected_response: int = 201, expected_headers: list = None) -> Response:
         response = self.client.post("/pub",
                                     data=data,

--- a/whyis/test/test_case.py
+++ b/whyis/test/test_case.py
@@ -1,7 +1,35 @@
 import flask_testing
 
+from flask import Response
+from rdflib import URIRef
+from typing import Optional, Dict
 
 class TestCase(flask_testing.TestCase):
+
+    def login_new_user(self, *, email: str = "user@example.com", password: str = "password", username: str = "identifier", role: str = 'Admin') -> Response:
+        return self.login(*self.create_user(email=email, password=password, username=username, roles=role))
+
+    def get_view(self, *, uri: URIRef, mime_type: str, view: Optional[str] = None, headers = None, expected_template: Optional[str] = None, query_string: Optional[Dict[str, str]]=None) -> Response:
+        query_string = query_string.copy() if query_string is not None else {}
+        query_string["uri"] = uri
+        if view is not None:
+            query_string["view"] = view
+
+        content = self.client.get("/about",
+                                  query_string=query_string,
+                                  headers=headers or {},
+                                  follow_redirects=True)
+        
+        if expected_template is not None:
+            self.assertTemplateUsed(expected_template)
+
+        if mime_type is not None:
+            self.assertEqual(content.mimetype, mime_type,
+                              "Expected {}, got {} as response MIME type".format(mime_type, content.mimetype))
+
+        return content
+
+    
     def create_app(self):
         from whyis import config_defaults
 


### PR DESCRIPTION
Add the FRIRArchiver agent to the configuration to enable nanopublication archiving. By default, the files will be deleted when the originating nanopublication is retired.