### PR TITLE
Drops api_test_data.py LOD_PREFIX / HOME_INSTANCE_URI and uses config instead

### DIFF
--- a/tests/api/view/test_labels_json_view.py
+++ b/tests/api/view/test_labels_json_view.py
@@ -1,10 +1,16 @@
-from ..api_test_data import HOME_INSTANCE_URI
 from whyis.test.api_test_case import ApiTestCase
 import json
 
 
 class TestLabelsJsonView(ApiTestCase):
     def test(self):
+        try:
+            import config
+        except:
+            from whyis import config_defaults as config
+        
+        HOME_INSTANCE_URI = config.LOD_PREFIX + "/Home"
+
         self.login_new_user()
 
         content = self.get_view(uri=HOME_INSTANCE_URI,

--- a/tests/api/view/test_latest_json_view.py
+++ b/tests/api/view/test_latest_json_view.py
@@ -1,10 +1,17 @@
-from ..api_test_data import HOME_INSTANCE_URI, PERSON_INSTANCE_TURTLE
+from ..api_test_data import PERSON_INSTANCE_TURTLE
 from whyis.test.api_test_case import ApiTestCase
 import json
 
 
 class TestLatestJsonView(ApiTestCase):
     def test(self):
+        try:
+            import config
+        except:
+            from whyis import config_defaults as config
+        
+        HOME_INSTANCE_URI = config.LOD_PREFIX + "/Home"
+
         self.login_new_user()
 
         self.post_nanopub(data=PERSON_INSTANCE_TURTLE,

--- a/tests/api/view/test_nanopublications_json_view.py
+++ b/tests/api/view/test_nanopublications_json_view.py
@@ -1,10 +1,15 @@
-from ..api_test_data import PERSON_INSTANCE_TURTLE, PERSON_INSTANCE_URI, LOD_PREFIX
+from ..api_test_data import PERSON_INSTANCE_TURTLE, PERSON_INSTANCE_URI
 from whyis.test.api_test_case import ApiTestCase
 import json
 
 
 class TestNanopublicationsJsonView(ApiTestCase):
     def test(self):
+        try:
+            import config
+        except:
+            from whyis import config_defaults as config
+        
         self.login_new_user()
         response = self.post_nanopub(data=PERSON_INSTANCE_TURTLE,
                                      content_type="text/turtle")
@@ -21,4 +26,4 @@ class TestNanopublicationsJsonView(ApiTestCase):
         self.assertEqual(1, len(json_content))
         nanopublication = json_content[0]
         self.assertIsInstance(nanopublication, dict)
-        self.assertEqual(nanopublication["contributor"], LOD_PREFIX + '/user/identifier')
+        self.assertEqual(nanopublication["contributor"], config.LOD_PREFIX + '/user/identifier')

--- a/whyis/test/test_case.py
+++ b/whyis/test/test_case.py
@@ -31,21 +31,24 @@ class TestCase(flask_testing.TestCase):
 
     
     def create_app(self):
-        from whyis import config_defaults
-
-        if 'admin_queryEndpoint' in config_defaults.Test:
-            del config_defaults.Test['admin_queryEndpoint']
-            del config_defaults.Test['admin_updateEndpoint']
-            del config_defaults.Test['knowledge_queryEndpoint']
-            del config_defaults.Test['knowledge_updateEndpoint']
+        try:
+            import config
+        except:
+            from whyis import config_defaults as config
+        
+        if 'admin_queryEndpoint' in config.Test:
+            del config.Test['admin_queryEndpoint']
+            del config.Test['admin_updateEndpoint']
+            del config.Test['knowledge_queryEndpoint']
+            del config.Test['knowledge_updateEndpoint']
 
         # Default port is 5000
-        config_defaults.Test['LIVESERVER_PORT'] = 8943
+        config.Test['LIVESERVER_PORT'] = 8943
         # Default timeout is 5 seconds
-        config_defaults.Test['LIVESERVER_TIMEOUT'] = 10
+        config.Test['LIVESERVER_TIMEOUT'] = 10
 
         from whyis.app_factory import app_factory
-        application = app_factory(config_defaults.Test, config_defaults.project_name)
+        application = app_factory(config.Test, config.project_name)
         application.config['TESTING'] = True
         application.config['WTF_CSRF_ENABLED'] = False
 


### PR DESCRIPTION
- `TestCase` decides if default or app config should be used
- Same strategy as above to `labels`, `latest` and `nanopublications` view tests