### PR TITLE
property path no longer blows up after adding lots of nanopubs.

### DIFF
--- a/main.py
+++ b/main.py
@@ -177,9 +177,9 @@ class App(Empty):
             '''gets called whenever there is a change in the knowledge graph.
             Performs a breadth-first knowledge expansion of the current change.'''
             #print "Updating on", nanopub_uri
-            if not app.nanopub_manager.is_current(nanopub_uri):
-                print("Skipping retired nanopub", nanopub_uri)
-                return
+            #if not app.nanopub_manager.is_current(nanopub_uri):
+            #    print("Skipping retired nanopub", nanopub_uri)
+            #    return
             nanopub = app.nanopub_manager.get(nanopub_uri)
             nanopub_graph = ConjunctiveGraph(nanopub.store)
             if 'inferencers' in self.config:

--- a/main.py
+++ b/main.py
@@ -45,7 +45,6 @@ from whyis.html_mime_types import HTML_MIME_TYPES
 from whyis.namespace import NS
 from whyis.nanopub import NanopublicationManager
 # from flask_login.config import EXEMPT_METHODS
-from whyis.task_utils import is_waiting, is_running_waiting
 
 rdflib.plugin.register('sparql', Result,
         'rdflib.plugins.sparql.processor', 'SPARQLResult')
@@ -187,14 +186,12 @@ class App(Empty):
                 for name, service in list(self.config['inferencers'].items()):
                     service.app = self
                     if service.query_predicate == self.NS.whyis.updateChangeQuery:
-                        #print "checking", name, nanopub_uri, service.get_query()
                         if service.getInstances(nanopub_graph):
                             print("invoking", name, nanopub_uri)
                             process_nanopub.apply_async(kwargs={'nanopub_uri': nanopub_uri, 'service_name':name}, priority=1 )
                 for name, service in list(self.config['inferencers'].items()):
                     service.app = self
-                    if service.query_predicate == self.NS.whyis.globalChangeQuery and not is_running_waiting(name):
-                        #print "checking", name, service.get_query()
+                    if service.query_predicate == self.NS.whyis.globalChangeQuery:
                         process_resource.apply_async(kwargs={'service_name':name}, priority=5)
 
         def run_update(nanopub_uri):

--- a/manage.py
+++ b/manage.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 from whyis.manager import Manager
 
 

--- a/reset_namespaces.sh
+++ b/reset_namespaces.sh
@@ -6,4 +6,4 @@ mkdir /data/nanopublications
 mkdir /data/files
 chown whyis:whyis /data/nanopublications /data/files
 #curl -X DELETE http://localhost:8080/blazegraph/namespace/admin
-#curl -X POST --data-binary @admin.properties -H 'Content-Type:text/plain' http://localhost:8080/blazegraph/namespace
+curl -X POST --data-binary @admin.properties -H 'Content-Type:text/plain' http://localhost:8080/blazegraph/namespace

--- a/whyis/nanopub/nanopublication_manager.py
+++ b/whyis/nanopub/nanopublication_manager.py
@@ -131,7 +131,7 @@ class NanopublicationManager(object):
         file_query = '''select ?fileid where {
   ?np np:hasAssertion ?assertion.
   graph ?assertion {
-    ?resource whis:hasFileID ?fileid.
+    ?resource whyis:hasFileID ?fileid.
   }
 }'''
         for nanopub_uri in nanopub_uris:


### PR DESCRIPTION
The query to find nanopublications was matching the ends of the old property path and finding intermediates one by one. This will limit the search space significantly.