### PR TITLE
Add vega vis depiction image

### DIFF
--- a/static/.gitignore
+++ b/static/.gitignore
@@ -1,4 +1,4 @@
 js/whyis_vue_bundle.js*
 node_modules/
 package-lock.json
-css/whyis_vue_bundle.css
+css/whyis_vue_bundle.css*

--- a/static/js/whyis_vue/components/pages/vega/editor/vega-editor-script.js
+++ b/static/js/whyis_vue/components/pages/vega/editor/vega-editor-script.js
@@ -51,6 +51,18 @@ export default Vue.component('vega-editor', {
     onSpecJsonError () {
       console.log('bad', arguments)
     },
+    async onNewVegaView (view) {
+      const blob = await view.toImageURL('png')
+        .then(url => fetch(url))
+        .then(resp => resp.blob())
+      const fr = new FileReader()
+      fr.addEventListener('load', () => {
+        this.chart.depiction = fr.result
+        // document.getElementById('page')
+        //   .appendChild(jQuery.parseHTML(`<img src="${fr.result}">`)[0])
+      })
+      fr.readAsDataURL(blob)
+    },
     loadChart () {
       let getChartPromise
       if (this.pageView === 'new') {

--- a/static/js/whyis_vue/components/pages/vega/editor/vega-editor.html
+++ b/static/js/whyis_vue/components/pages/vega/editor/vega-editor.html
@@ -56,7 +56,7 @@
           <md-tabs>
             <md-tab md-label="Chart">
               <div class="vega-container">
-                <vega-lite :spec="spec"/>
+                <vega-lite :spec="spec" @new-vega-view="onNewVegaView"/>
               </div>
             </md-tab>
             <md-tab md-label="Table">

--- a/static/js/whyis_vue/components/pages/vega/gallery/vega-gallery.vue
+++ b/static/js/whyis_vue/components/pages/vega/gallery/vega-gallery.vue
@@ -26,7 +26,7 @@ export default Vue.component('vega-gallery', {
   created () {
     this.loading = true
     getCharts()
-      .then((charts) => this.charts = charts)
+      .then((charts) => {this.charts = charts; console.log(charts)})
       .finally(() => this.loading = false)
   }
 })

--- a/static/js/whyis_vue/components/vega-lite-wrapper.vue
+++ b/static/js/whyis_vue/components/vega-lite-wrapper.vue
@@ -32,9 +32,10 @@ export default Vue.component('vega-lite', {
     this.onSpecChange()
   },
   methods: {
-    plotSpec () {
+    async plotSpec () {
       console.debug('plotting spec', this.spec)
-      window.vegaEmbed(`#${this.id}`, this.spec)
+      let embedResult = await window.vegaEmbed(`#${this.id}`, this.spec)
+      this.$emit('new-vega-view', embedResult.view)
     },
     validateSpec () {
       const validation = jsonValidate(this.spec, vegaLiteSchema)

--- a/static/js/whyis_vue/utilities/vega-chart.js
+++ b/static/js/whyis_vue/utilities/vega-chart.js
@@ -44,7 +44,8 @@ const chartFieldUris = {
   baseSpec: 'http://semanticscience.org/resource/hasValue',
   query: 'http://schema.org/query',
   title: 'http://purl.org/dc/terms/title',
-  description: 'http://purl.org/dc/terms/description'
+  description: 'http://purl.org/dc/terms/description',
+  depiction: 'http://xmlns.com/foaf/0.1/depiction'
 }
 
 const chartPrefix = 'viz'
@@ -75,10 +76,16 @@ function buildChartLd (chart) {
 
 function extractChart (chartLd) {
   const chart = Object.entries(chartFieldUris)
-    .reduce((o, [field, uri]) => Object.assign(o, { [field]: chartLd[uri][0]['@value'] }), {})
+    .reduce((o, [field, uri]) => {
+      let value = ""
+      if (uri in chartLd) {
+        value = chartLd[uri][0]['@value']
+      }
+      o[field] = value
+      return o
+    }, {})
   chart.baseSpec = JSON.parse(chart.baseSpec)
   chart.uri = chartLd['@id']
-
   return chart
 }
 

--- a/static/js/whyis_vue/utilities/vega-chart.js
+++ b/static/js/whyis_vue/utilities/vega-chart.js
@@ -149,13 +149,15 @@ const chartQuery = `
   PREFIX schema: <http://schema.org/>
   PREFIX sio: <http://semanticscience.org/resource/>
   PREFIX owl: <http://www.w3.org/2002/07/owl#>
-  SELECT DISTINCT ?chart ?title ?description ?query ?baseSpec
+  PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+  SELECT DISTINCT ?uri ?title ?description ?query ?baseSpec ?depiction
   WHERE {
-    ?chart a sio:Chart .
-    ?chart dcterms:title ?title .
-    ?chart dcterms:description ?description .
-    ?chart schema:query ?query .
-    ?chart sio:hasValue ?baseSpec
+    ?uri a sio:Chart ;
+         dcterms:title ?title ;
+         dcterms:description ?description ;
+         schema:query ?query ;
+         sio:hasValue ?baseSpec ;
+         foaf:depiction ?depiction .
   }
   `
 
@@ -163,13 +165,9 @@ function getCharts () {
   return querySparql(chartQuery)
     .then(data =>
       data.results.bindings.map((chartResult) => {
-        const chart = Object.entries(chartResult)
-          .reduce((o, [field, value]) => {
-            o[field] = value.value
-            return o
-          }, {})
-        chart.uri = chart.chart
-        delete chart.chart
+        const chart = {}
+        Object.entries(chartResult)
+          .forEach(([field, value]) => chart[field] = value.value)
         chart.baseSpec = JSON.parse(chart.baseSpec)
         return chart
       })

--- a/whyis/filters.py
+++ b/whyis/filters.py
@@ -142,7 +142,7 @@ def configure(app):
         result['description'] = sorted(result['description'], key=lambda x: len(x['value']))
         thumbnail = this.description().value(app.NS.foaf.depiction)
         if thumbnail is not None:
-            result['thumbnail'] = thumbnail.identifier
+            result['thumbnail'] = thumbnail.value if type(thumbnail) is rdflib.Literal else thumbnail.identifier
         labelize(result, key="@id")
         attrs = query_filter(query, values=dict(this=this.identifier))
         for attr in attrs:

--- a/whyis/filters.py
+++ b/whyis/filters.py
@@ -142,7 +142,7 @@ def configure(app):
         result['description'] = sorted(result['description'], key=lambda x: len(x['value']))
         thumbnail = this.description().value(app.NS.foaf.depiction)
         if thumbnail is not None:
-            result['thumbnail'] = thumbnail.value if type(thumbnail) is rdflib.Literal else thumbnail.identifier
+            result['thumbnail'] = thumbnail.identifier
         labelize(result, key="@id")
         attrs = query_filter(query, values=dict(this=this.identifier))
         for attr in attrs:


### PR DESCRIPTION
Save a png data uri as the foaf:depiction for vega editor visualizations.

I needed to modify the handling of depictions in the attribute filter in filter.py.