### PR TITLE
Fix bugs causing CI failures

### DIFF
--- a/docker/image/whyis-integration/Dockerfile
+++ b/docker/image/whyis-integration/Dockerfile
@@ -1,5 +1,5 @@
 # For running CI purposes
-FROM cypress/included:3.2.0
+FROM cypress/included:3.8.3
 
 COPY docker/image/whyis-integration/docker-entrypoint.sh /
 COPY docker/image/whyis-integration/cypress.json /integration/

--- a/docker/image/whyis-integration/cypress.json
+++ b/docker/image/whyis-integration/cypress.json
@@ -2,8 +2,8 @@
     "baseUrl": "http://whyis",
     "reporter": "junit",
     "reporterOptions": {
-	"mochaFile": "results/results-[hash].xml",
-	"toConsole": false
+        "mochaFile": "results/results-[hash].xml",
+        "toConsole": false
     },
     "screenshotsFolder": "results/screenshots",
     "videosFolder": "results/videos"

--- a/docker/image/whyis-integration/docker-entrypoint.sh
+++ b/docker/image/whyis-integration/docker-entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 CYPRESS_baseUrl=http://whyis
 
-curl --retry 5 --retry-connrefused http://whyis > /dev/null
+curl --retry 5 --retry-connrefused "$CYPRESS_baseUrl" > /dev/null
 cypress run --spec cypress/integration/whyis/**/*
 tar cf test-results-js.tar results

--- a/docker/image/whyis/Dockerfile
+++ b/docker/image/whyis/Dockerfile
@@ -8,7 +8,7 @@ RUN mvn -q clean compile assembly:single -PwhyisProfile
 FROM node:12-alpine as build-js
 COPY static /static
 WORKDIR /static
-RUN npm ci
+RUN npm install
 RUN npm run build
 
 # Deploy image from here

--- a/tests/integration/cypress.json
+++ b/tests/integration/cypress.json
@@ -1,3 +1,3 @@
 {
-    "baseUrl": "http://localhost:5000",
+    "baseUrl": "http://localhost"
 }


### PR DESCRIPTION
- use the latest cypress 3 image for end to end testing
- Revert change to use `npm ci` during build instead of `npm install`.  `npm ci` requires you to commit `package-lock.json`, which we don't do