### PR TITLE
Small tweaks to dev docker compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 /.git/
 /.idea/
-node_modules/
+/static/node_modules/
 package-lock.json
 *.pyc
 __pycache__/

--- a/docker/compose/monolithic/dev-entrypoint.sh
+++ b/docker/compose/monolithic/dev-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+python3 manage.py createuser -e whyis@whyis.com -p whyis -u whyis --roles=admin
+python3 manage.py runserver -h 0.0.0.0

--- a/docker/compose/monolithic/docker-compose.dev.yml
+++ b/docker/compose/monolithic/docker-compose.dev.yml
@@ -36,6 +36,6 @@ services:
       - ./../../../whyis:/whyis
       - ./../../../manage.py:/manage.py
       - ./dev-entrypoint.sh:/dev-entrypoint.sh
-    command: /dev-entrypoint.sh
+    command: sh /dev-entrypoint.sh
 
 

--- a/docker/compose/monolithic/docker-compose.dev.yml
+++ b/docker/compose/monolithic/docker-compose.dev.yml
@@ -28,13 +28,14 @@ services:
       - "9000:9000"
       - "5000:5000"
     volumes:
-      - ./../../../../../data:/data
+      # - ./../../../../../data:/data
       - ./../../../tests/integration:/tests/integration
       - ./../../../static:/static
       - ./../../../templates:/templates
       - ./../../../default_vocab.ttl:/default_vocab.ttl
       - ./../../../whyis:/whyis
       - ./../../../manage.py:/manage.py
-    command: bash -c "python3 manage.py createuser -e whyis@whyis.com -p whyis -u whyis --roles=admin && python3 manage.py runserver -h 0.0.0.0"
+      - ./dev-entrypoint.sh:/dev-entrypoint.sh
+    command: /dev-entrypoint.sh
 
-  
+


### PR DESCRIPTION
- Comment out /data volume mount.  It can be problematic and is not
  needed for basic development.
- Express commands to start dev server in shell file instead of one long
  bash command.
- Fix dockerignore of node modules