### PR TITLE
accept string uris in labelize

### DIFF
--- a/whyis/filters.py
+++ b/whyis/filters.py
@@ -44,13 +44,16 @@ def configure(app):
         if key not in entry:
             return None
         resource = None
-        if not isinstance(entry[key],rdflib.URIRef):
+        try:
+            key_uri = rdflib.URIRef(entry[key])
+            key_uri.n3()
+        except Exception:
             entry[label_key] = entry[key]
             return entry
         if fetch:
-            resource = app.get_resource(rdflib.URIRef(entry[key]))
+            resource = app.get_resource(key_uri)
         else:
-            resource = app.Entity(app.db, rdflib.URIRef(entry[key]))
+            resource = app.Entity(app.db, key_uri)
         entry[label_key] = app.get_label(resource.description())
         return entry
 


### PR DESCRIPTION
The labelize filter is rejecting uris that aren't instances of rdflib.URIRef and defaulting the label to the uri.

This change removes the instance check and replaces it with a validation check of the passed in uri.  This allows labelize to accept uri values in the form of strings.