### PR TITLE
Fix uri for view=resolve in add-knowledge components

### DIFF
--- a/static/js/whyis_vue/components/add-attribute.vue
+++ b/static/js/whyis_vue/components/add-attribute.vue
@@ -339,15 +339,16 @@ export default Vue.component('add-attribute', {
         },
 
         async getAttributeList (query) {
+	    var combinedList = [];
             const [rdfsProperty, owlDatatypeProperty] = await axios.all([
                 axios.get(
-                `/?term=*${query}*&view=resolve&type=http://www.w3.org/1999/02/22-rdf-syntax-ns%23Property`),
+                `/about?term=*${query}*&view=resolve&type=http://www.w3.org/1999/02/22-rdf-syntax-ns%23Property`),
                 axios.get(
-                `/?term=*${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23DatatypeProperty`)
+                `/about?term=*${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23DatatypeProperty`)
             ]).catch((err) => {
                 throw(err)
             })
-            var combinedList = owlDatatypeProperty.data.concat(rdfsProperty.data)
+            combinedList = owlDatatypeProperty.data.concat(rdfsProperty.data)
             .sort((a, b) => (a.score < b.score) ? 1 : -1);
             let grouped = this.groupBy(combinedList, "node")
             return grouped

--- a/static/js/whyis_vue/components/add-attribute.vue
+++ b/static/js/whyis_vue/components/add-attribute.vue
@@ -334,7 +334,7 @@ export default Vue.component('add-attribute', {
 
         async getSuggestedAttributes (uri){
             const suggestedTypes = await axios.get(
-                `/about?view=suggested_attributes&uri=${uri}`)
+                `${ROOT_URL}about?view=suggested_attributes&uri=${uri}`)
             return suggestedTypes.data
         },
 
@@ -342,9 +342,9 @@ export default Vue.component('add-attribute', {
 	    var combinedList = [];
             const [rdfsProperty, owlDatatypeProperty] = await axios.all([
                 axios.get(
-                `/about?term=*${query}*&view=resolve&type=http://www.w3.org/1999/02/22-rdf-syntax-ns%23Property`),
+                `${ROOT_URL}about?term=*${query}*&view=resolve&type=http://www.w3.org/1999/02/22-rdf-syntax-ns%23Property`),
                 axios.get(
-                `/about?term=*${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23DatatypeProperty`)
+                `${ROOT_URL}about?term=*${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23DatatypeProperty`)
             ]).catch((err) => {
                 throw(err)
             })

--- a/static/js/whyis_vue/components/add-link.vue
+++ b/static/js/whyis_vue/components/add-link.vue
@@ -262,15 +262,16 @@ export default Vue.component('add-link', {
         },
 
         async getPropertyList (query) {
+	    var combinedList = [];
             const [rdfsProperty, owlObjectProperty] = await axios.all([
                 axios.get(
-                `/?term=*${query}*&view=resolve&type=http://www.w3.org/1999/02/22-rdf-syntax-ns%23Property`),
+                `/about?term=*${query}*&view=resolve&type=http://www.w3.org/1999/02/22-rdf-syntax-ns%23Property`),
                 axios.get(
-                `/?term=*${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23ObjectProperty`)
+                `/about?term=*${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23ObjectProperty`)
             ]).catch((err) => {
                 throw(err)
             })
-            var combinedList = owlObjectProperty.data.concat(rdfsProperty.data)
+            combinedList = owlObjectProperty.data.concat(rdfsProperty.data)
             .sort((a, b) => (a.score < b.score) ? 1 : -1);
             let grouped = this.groupBy(combinedList, "node")
             return grouped
@@ -284,7 +285,7 @@ export default Vue.component('add-link', {
 
         async getEntityList (query) {
             const entityList = await axios.get(
-                `/?term=*${query}*&view=resolve`)
+                `/about?term=*${query}*&view=resolve`)
             return entityList.data
         },
 

--- a/static/js/whyis_vue/components/add-link.vue
+++ b/static/js/whyis_vue/components/add-link.vue
@@ -257,7 +257,7 @@ export default Vue.component('add-link', {
 
         async getSuggestedProperties (uri){
             const suggestedTypes = await axios.get(
-                `/about?view=suggested_links&uri=${uri}`)
+                `${ROOT_URL}about?view=suggested_links&uri=${uri}`)
             return suggestedTypes.data.outgoing
         },
 
@@ -265,9 +265,9 @@ export default Vue.component('add-link', {
 	    var combinedList = [];
             const [rdfsProperty, owlObjectProperty] = await axios.all([
                 axios.get(
-                `/about?term=*${query}*&view=resolve&type=http://www.w3.org/1999/02/22-rdf-syntax-ns%23Property`),
+                `${ROOT_URL}about?term=*${query}*&view=resolve&type=http://www.w3.org/1999/02/22-rdf-syntax-ns%23Property`),
                 axios.get(
-                `/about?term=*${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23ObjectProperty`)
+                `${ROOT_URL}about?term=*${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23ObjectProperty`)
             ]).catch((err) => {
                 throw(err)
             })
@@ -279,13 +279,13 @@ export default Vue.component('add-link', {
 
         async getNeighborEntities (uri) {
             const neighborEntities = await axios.get(
-                `/about?view=neighbors&uri=${uri}`)
+                `${ROOT_URL}about?view=neighbors&uri=${uri}`)
             return neighborEntities.data
         },
 
         async getEntityList (query) {
             const entityList = await axios.get(
-                `/about?term=*${query}*&view=resolve`)
+                `${ROOT_URL}about?term=*${query}*&view=resolve`)
             return entityList.data
         },
 

--- a/static/js/whyis_vue/components/add-type.vue
+++ b/static/js/whyis_vue/components/add-type.vue
@@ -200,7 +200,7 @@ export default Vue.component('add-type', {
 
         async getSuggestedTypes (uri){
             const suggestedTypes = await axios.get(
-                `/about?view=suggested_types&uri=${uri}`)
+                `${ROOT_URL}about?view=suggested_types&uri=${uri}`)
             return suggestedTypes.data
         },
 
@@ -208,9 +208,9 @@ export default Vue.component('add-type', {
             var combinedList = [];
             const [rdfsClass, owlClass] = await axios.all([
                 axios.get(
-                `/about?term=${query}*&view=resolve&type=http://www.w3.org/2000/01/rdf-schema%23Class`),
+                `${ROOT_URL}about?term=${query}*&view=resolve&type=http://www.w3.org/2000/01/rdf-schema%23Class`),
                 axios.get(
-                `/about?term=${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23Class`)
+                `${ROOT_URL}about?term=${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23Class`)
             ]).catch((err) => {
                 throw(err)
             })

--- a/static/js/whyis_vue/components/add-type.vue
+++ b/static/js/whyis_vue/components/add-type.vue
@@ -39,9 +39,22 @@
                 </template>
             
                 <template style="width: 90% !important; left: 1px !important" slot="md-autocomplete-empty" slot-scope="{ term }">
-                <p>No types or classes matching "{{ term }}" were found.</p>
+                <p v-if="term">No types or classes matching "{{ term }}" were found.</p>
+                <p v-else> Enter a type name.</p>
+                <a v-on:click="useCustomURI" style="cursor: pointer">Use a custom type URI</a>         
                 </template>
             </md-autocomplete>
+            <div v-if="useCustom" class="md-layout md-gutter">
+                <div class="md-layout-item">
+                    <md-field>
+                        <label>Full URI of type</label>
+                        <md-input v-model="customTypeURI"></md-input>
+                    <md-button v-on:click="submitCustomURI" class="md-raised">
+                        Confirm URI
+                    </md-button>
+                    </md-field>
+                </div>
+            </div>
             <div
                 v-for="(chip, key) in typeChips" 
                 v-bind:key="key + 'chips'">
@@ -89,6 +102,8 @@ export default Vue.component('add-type', {
     data: function() {
         return {
             id: null,
+            useCustom: false,
+            customTypeURI: null,
             typeList: [],
             selectedType: null,
             typeChips: [],
@@ -102,6 +117,18 @@ export default Vue.component('add-type', {
         showSuggestedTypes(){
             this.processAutocompleteMenu();
             this.typeList = this.getSuggestedTypes(this.uri);
+        },
+        useCustomURI(){
+            this.useCustom = true;
+        },
+        submitCustomURI(){
+            var newChip = {
+                label: this.customTypeURI,
+                node: this.customTypeURI, 
+            }
+            this.typeChips.push(newChip);
+            this.customTypeURI = "";
+            this.useCustom = false
         },
         resolveEntityType(query){
             var thisVue = this;
@@ -127,7 +154,9 @@ export default Vue.component('add-type', {
         },
         resetDialogBox(){
             this.active = !this.active;
-            this.typeChips = []
+            this.typeChips = [];
+            this.customTypeURI = "";
+            this.useCustom = false;
         },
         onCancel() {
             return this.resetDialogBox();
@@ -176,15 +205,16 @@ export default Vue.component('add-type', {
         },
 
         async getTypeList (query) {
+            var combinedList = [];
             const [rdfsClass, owlClass] = await axios.all([
                 axios.get(
-                `/?term=${query}*&view=resolve&type=http://www.w3.org/2000/01/rdf-schema%23Class`),
+                `/about?term=${query}*&view=resolve&type=http://www.w3.org/2000/01/rdf-schema%23Class`),
                 axios.get(
-                `/?term=${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23Class`)
+                `/about?term=${query}*&view=resolve&type=http://www.w3.org/2002/07/owl%23Class`)
             ]).catch((err) => {
                 throw(err)
             })
-            var combinedList = owlClass.data.concat(rdfsClass.data)
+            combinedList = owlClass.data.concat(rdfsClass.data)
             .sort((a, b) => (a.score < b.score) ? 1 : -1);
             let grouped = this.groupBy(combinedList, "node")
             return grouped


### PR DESCRIPTION
Needed to add `about` to the URI since home defaults to nm rather than wi. 
Also added ability to input custom URIs in add-type