### PR TITLE
added: 'will only work if your project name was set to whyis_demo'

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -66,7 +66,7 @@ whyis$ python manage.py configure
 
 -- Version, packages, secret key, and salt can be left at default values
 
-Once the knowledge graph instance is created, go to that folder:
+Once the knowledge graph instance is created, go to that folder (will only work if your project name is whyis_demo):
 ```shell
 whyis$ cd ../whyis_demo/
 ```


### PR DESCRIPTION
Pay attention because "whyis_demo" will fail, as the default project name was set before to "my_knowledge_graph".

=> noting important, but just looking to start our collaboration process. 